### PR TITLE
Predictive validity in a different space

### DIFF
--- a/src/curvefit/model.py
+++ b/src/curvefit/model.py
@@ -325,7 +325,7 @@ class CurveModel:
         self.result = result
         self.params = self.compute_params(self.result.x, expand=False)
 
-    def predict(self, t, group_name='all'):
+    def predict(self, t, group_name='all', prediction_functional_form=None):
         """Predict the observation by given independent variable and group name.
 
         Args:
@@ -334,6 +334,9 @@ class CurveModel:
             group_name (dtype(group_names) | str, optional):
                 If all will produce average curve and if specific group name
                 will produce curve for the group.
+            prediction_functional_form (function):
+                One of the functions from curvefit.functions
+                Needs to have the same parameters as self.fun
 
         Returns:
             numpy.ndarray:
@@ -342,10 +345,14 @@ class CurveModel:
         if group_name == 'all':
             params = self.params.mean(axis=1)
         else:
-            params = self.params[:,
-                                 np.where(self.group_names==group_name)[0][0]]
+            params = self.params[:, np.where(self.group_names == group_name)[0][0]]
 
-        return self.fun(t, params)
+        if prediction_functional_form is not None:
+            fun = self.fun
+        else:
+            fun = prediction_functional_form
+
+        return fun(t, params)
 
     def estimate_obs_se(self, radius=3.0, se_floor=0.5):
         """Estimate the observation standard error.

--- a/src/curvefit/model_generators.py
+++ b/src/curvefit/model_generators.py
@@ -1,0 +1,53 @@
+from curvefit.model import CurveModel
+
+
+class BasicModelGenerator:
+    def __init__(self, col_t, col_obs, col_covs, col_group,
+                 param_names, link_fun, fit_fun, predict_fun, var_link_fun, predict_group='all',
+                 **fit_kwargs):
+        """
+        Generic class for a function to produce predictions from a model
+        with the following attributes.
+
+        Args:
+            col_t:
+            col_obs:
+            col_covs:
+            col_group:
+            param_names:
+            link_fun:
+            fit_fun:
+            predict_fun:
+            var_link_fun:
+            predict_group:
+            **fit_kwargs: keyword arguments to CurveModel.fit_params()
+        """
+        self.col_t = col_t
+        self.col_obs = col_obs
+        self.col_covs = col_covs
+        self.col_group = col_group
+        self.param_names = param_names
+        self.link_fun = link_fun
+        self.fit_fun = fit_fun
+        self.predict_fun = predict_fun
+        self.var_link_fun = var_link_fun
+        self.predict_group = predict_group
+        self.fit_kwargs = fit_kwargs
+
+    def model_function(self, df, times):
+        mod = CurveModel(
+            df=df,
+            col_t=self.col_t,
+            col_obs=self.col_obs,
+            col_covs=self.col_covs,
+            col_group=self.col_group,
+            param_names=self.param_names,
+            link_fun=self.link_fun,
+            fun=self.fit_fun,
+            var_link_fun=self.var_link_fun
+        )
+        mod.fit_params(**self.fit_kwargs)
+        return mod.predict(
+            t=times, group_name=self.predict_group,
+            prediction_functional_form=self.predict_fun
+        )

--- a/src/curvefit/model_generators.py
+++ b/src/curvefit/model_generators.py
@@ -1,6 +1,9 @@
 """
 All classes of model generators should have a model_function that takes arguments
 df and times and returns predictions at those times.
+
+**NOTE**: This is useful for the predictive validity functions that need a fit_model
+function that takes those arguments. That callable will be generated with the model_function in these classes.
 """
 
 from curvefit.model import CurveModel

--- a/src/curvefit/model_generators.py
+++ b/src/curvefit/model_generators.py
@@ -1,3 +1,8 @@
+"""
+All classes of model generators should have a model_function that takes arguments
+df and times and returns predictions at those times.
+"""
+
 from curvefit.model import CurveModel
 
 

--- a/src/curvefit/pv.py
+++ b/src/curvefit/pv.py
@@ -42,7 +42,7 @@ def get_full_data(grp_df, col_t, col_obs, prediction_times):
             column
         col_t: (str) the time column
         col_obs: (str) the observation column
-        prediction_times: (str) the time vector for which predictions are needed
+        prediction_times: (np.array) the time vector for which predictions are needed
 
     Returns:
         (np.array) observations filled out to the max time point
@@ -59,7 +59,7 @@ def get_full_data(grp_df, col_t, col_obs, prediction_times):
     return full_data
 
 
-def pv_for_single_group(grp_df, col_t, col_obs, fit_model):
+def pv_for_single_group(grp_df, col_t, col_obs, col_obs_compare, fit_model):
     """
     Gets forward out of sample predictive validity for a model based on the function
     fit_model that takes arguments df and times and returns predictions at times.
@@ -68,6 +68,9 @@ def pv_for_single_group(grp_df, col_t, col_obs, fit_model):
         grp_df: (pd.DataFrame)
         col_t: (str) column indicating the time
         col_obs: (str) column indicating the observation
+        col_obs_compare: (str) column indicating the observation that represents the space we will
+            be calculating predictive validity in (can be different from col_obs, but your fit_model
+            function for predict should match that)
         fit_model: function that takes arguments df and times and returns predictions
             at the vector passed in for times
 
@@ -101,21 +104,24 @@ def pv_for_single_group(grp_df, col_t, col_obs, fit_model):
         for i in prediction_times
     ])
     full_data = get_full_data(
-        grp_df=grp_df, col_t=col_t, col_obs=col_obs, prediction_times=prediction_times
+        grp_df=grp_df, col_t=col_t, col_obs=col_obs_compare, prediction_times=prediction_times
     )
     residuals = all_preds - np.array(full_data)
 
     return prediction_times, all_preds, residuals
 
 
-def pv_for_group_collection(df, col_group, col_t, col_obs, fit_model):
+def pv_for_group_collection(df, col_group, col_t, col_obs, col_obs_compare, fit_model):
     """
     Gets a dictionary of predictive validity for all groups in the data frame.
     Args:
         df: (pd.DataFrame)
         col_group: (str) grouping column string
         col_t: (str) column indicating the time
-        col_obs: (str) column indicating the observation
+        col_obs: (str) column indicating the observation for fitting
+        col_obs_compare: (str) column indicating the observation that represents the space we will
+            be calculating predictive validity in (can be different from col_obs, but your fit_model
+            function for predict should match that)
         fit_model: function that takes arguments df and times and returns predictions
             at the vector passed in for times
 
@@ -135,7 +141,11 @@ def pv_for_group_collection(df, col_group, col_t, col_obs, fit_model):
         print(f"Getting PV for group {grp}")
         grp_df = df.loc[df[col_group] == grp].copy()
         times, preds, resid = pv_for_single_group(
-            grp_df=grp_df, col_t=col_t, col_obs=col_obs, fit_model=fit_model
+            grp_df=grp_df,
+            col_t=col_t,
+            col_obs=col_obs,
+            col_obs_compare=col_obs_compare,
+            fit_model=fit_model
         )
         prediction_times[grp] = times
         prediction_results[grp] = preds


### PR DESCRIPTION
Can fit and predict in different spaces now with BasicModelGenerator in `model_generators.py`. Can make more model generators as long as they output a prediction array at requested times. For example could build a `BlendModelGenerator` that blends a tight and loose model.