### PR TITLE
Momentum // exponential smoothing

### DIFF
--- a/src/curvefit/diagnostics/plot_diagnostics.py
+++ b/src/curvefit/diagnostics/plot_diagnostics.py
@@ -4,9 +4,9 @@ import numpy as np
 from curvefit.core.utils import data_translator
 
 
-def plot_uncertainty(generator, prediction_times, sharex, sharey, draw_space, plot_obs):
+def plot_fits(generator, prediction_times, sharex, sharey, draw_space, plot_obs=None, plot_uncertainty=False):
     """
-    Plot the draws from a model generator at some prediction times.
+    Plot the result and draws from a model generator at some prediction times.
 
     Args:
         generator: (curvefit.model_generator.ModelPipeline) that has some draws
@@ -14,10 +14,13 @@ def plot_uncertainty(generator, prediction_times, sharex, sharey, draw_space, pl
         sharex: (bool) fix the x axes
         sharey: (bool) fix the y axes
         draw_space: (callable) which curvefit.functions space to plot the draws in
-        plot_obs: (str) column of observations to plot,
+        plot_obs: (optional str) column of observations to plot
+        plot_uncertainty: (optional bool) plot the uncertainty intervals
     """
     fig, ax = plt.subplots(len(generator.groups), 1, figsize=(8, 4 * len(generator.groups)),
                            sharex=sharex, sharey=sharey)
+    if len(generator.groups) == 1:
+        ax = [ax]
     for i, group in enumerate(generator.groups):
         draws = generator.draws[group].copy()
         draws = data_translator(
@@ -32,17 +35,56 @@ def plot_uncertainty(generator, prediction_times, sharex, sharey, draw_space, pl
             output_space=draw_space
         )
         mean = draws.mean(axis=0)
-        lower = np.quantile(draws, axis=0, q=0.025)
-        upper = np.quantile(draws, axis=0, q=0.975)
-
         ax[i].plot(prediction_times, mean, c='red', linestyle=':')
-        ax[i].plot(prediction_times, lower, c='red', linestyle=':')
-        ax[i].plot(prediction_times, upper, c='red', linestyle=':')
-
         ax[i].plot(prediction_times, mean_fit, c='black')
-        df_data = generator.all_data.loc[generator.all_data[generator.col_group] == group].copy()
-        ax[i].scatter(df_data[generator.col_t], df_data[plot_obs])
+
+        if plot_uncertainty:
+            lower = np.quantile(draws, axis=0, q=0.025)
+            upper = np.quantile(draws, axis=0, q=0.975)
+            ax[i].plot(prediction_times, lower, c='red', linestyle=':')
+            ax[i].plot(prediction_times, upper, c='red', linestyle=':')
+
+        if plot_obs is not None:
+            df_data = generator.all_data.loc[generator.all_data[generator.col_group] == group].copy()
+            ax[i].scatter(df_data[generator.col_t], df_data[plot_obs])
+
         ax[i].set_title(f"{group} predictions")
+
+
+def plot_es(pv_group, exp_smoothing, prediction_times, max_last):
+    """
+    Plot results with different levels of exponential smoothing.
+
+    Args:
+        pv_group: (curvefit.pv.pv.PVGroup)
+        exp_smoothing: (np.array) exponential smoothing parameter
+        prediction_times: (np.array) prediction times
+        max_last: (int) number of last times to consider
+
+    Returns:
+
+    """
+    fig, ax = plt.subplots(1, 1, figsize=(12, 8))
+
+    times = pv_group.times
+    observations = pv_group.compare_observations
+
+    for i, exp in enumerate(exp_smoothing):
+        p = ax.plot(
+            prediction_times,
+            pv_group.exp_smooth_preds(
+                exp_smoothing=exp,
+                prediction_times=prediction_times,
+                max_last=max_last
+            ),
+            label=str(exp),
+        )
+        leg = ax.legend([p], [str(exp)])
+        ax.add_artist(leg)
+
+    ax.scatter(times, observations, zorder=len(exp_smoothing), color='black')
+    ax.set_title(f"{pv_group.predict_group}")
+    ax.legend()
 
 
 def plot_residuals_1d(residual_df, group_col, x_axis,

--- a/src/curvefit/pv/pv.py
+++ b/src/curvefit/pv/pv.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from curvefit.diagnostics.plot_diagnostics import plot_residuals, plot_predictions, plot_residuals_1d
+from curvefit.diagnostics.plot_diagnostics import plot_residuals, plot_predictions, plot_residuals_1d, plot_es
 from curvefit.core.utils import neighbor_mean_std
 
 
@@ -162,6 +162,74 @@ class PVGroup:
             'data_index': self.residuals[:, 0] + self.residuals[:, 1],
             'residual': self.residuals[:, 2]
         })
+
+    def get_exponential_weights(self, exp_smoothing, max_last):
+        """
+        Get what the exponential weighting function result is based on the parameter.
+
+        Args:
+            exp_smoothing: (float) exponential smoothing parameter -->
+                larger value will give more weight to more "recent" models
+            max_last: (optional int) number of previous times to consider
+
+        Returns:
+
+        """
+        times = self.times[-max_last:]
+
+        weights = np.exp(-exp_smoothing * (np.max(times) - times))
+        weights = weights / sum(weights)
+        return weights
+
+    def exp_smooth_preds(self, exp_smoothing, prediction_times, max_last=None):
+        """
+        Create a smoothed set of predictions with exponentially decreasing weights to further back
+        forecasts.
+
+        Args:
+            exp_smoothing: (float) exponential smoothing parameter -->
+                larger value will give more weight to more "recent" models
+            prediction_times: (np.array) times to predict at
+            max_last: (optional int) number of previous times to consider
+
+        Returns:
+            (np.array) of length prediction times
+        """
+        if max_last is None:
+            max_last = len(self.times)
+
+        weights = self.get_exponential_weights(
+            exp_smoothing=exp_smoothing,
+            max_last=max_last
+        )
+        weights = weights.reshape((len(weights), 1))
+        predictions = []
+        for i, t in enumerate(self.times[-max_last:]):
+            predictions.append(self.models[-max_last:][i].predict(
+                times=prediction_times,
+                predict_space=self.predict_space,
+                predict_group=self.predict_group
+            ))
+
+        weighted_predictions = np.vstack(predictions) * weights
+        smooth_predictions = weighted_predictions.sum(axis=0)
+
+        return smooth_predictions
+
+    def plot_exponential_smoothing(self, exp_smoothing, prediction_times, max_last=None):
+        """
+        Plot exponential smoothing results.
+
+        Args:
+            exp_smoothing: (np.array) exponential smoothing parameter
+            prediction_times: (np.array) prediction times
+            max_last: (int) number of last times to consider
+
+        Returns:
+
+        """
+        plot_es(pv_group=self, exp_smoothing=exp_smoothing,
+                prediction_times=prediction_times, max_last=max_last)
 
 
 class PVModel:

--- a/src/curvefit/pv/pv.py
+++ b/src/curvefit/pv/pv.py
@@ -190,7 +190,7 @@ class PVGroup:
             exp_smoothing: (float) exponential smoothing parameter -->
                 larger value will give more weight to more "recent" models
             prediction_times: (np.array) times to predict at
-            max_last: (optional int) number of previous times to consider
+            max_last: (optional int) number of previous models to consider
 
         Returns:
             (np.array) of length prediction times
@@ -223,7 +223,7 @@ class PVGroup:
         Args:
             exp_smoothing: (np.array) exponential smoothing parameter
             prediction_times: (np.array) prediction times
-            max_last: (int) number of last times to consider
+            max_last: (int) number of previous models to consider
 
         Returns:
 


### PR DESCRIPTION
Added the option to average the predictions over the last `max_last` most recent models (recent defined by dropping `i = 1, 2, ..., max_last` recent data points). Uses exponential weighting parameter `exp_smoothing`.

Added diagnostics as part of `curvefit.pv.pv.pv_groups` to look at the effect of different exponential smoothing parameters for a given `max_last` number of most recent models.