### PR TITLE
Add spell checking to extract_md.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ experiments
 *.swp
 # python compiled files in any directory
 *.pyc
+# temporary file names in any directory
+junk
+junk.*

--- a/docs/extract_md.py
+++ b/docs/extract_md.py
@@ -13,7 +13,7 @@ file_list = [
     'docs/extract_md.py',
 ]
 # ----------------------------------------------------------------------------
-'''[begin_markdown extract_md]
+'''{begin_markdown extract_md}
 # Extracting Markdown Documentation From Soure Code
 
 ## Syntax
@@ -34,7 +34,7 @@ that the markdown files will be extracted from.
 The start of a markdown section of the input file is indicated by the following
 text:
 <p style="margin-left:10%">
-[begin_markdown <i>section_name</i>]
+{begin_markdown <i>section_name</i>}
 <p/>
 Here *section_name* is the name of output file corresponding to this section.
 This name does not inlucde the *output_dir* or the .md extension.
@@ -43,7 +43,7 @@ This name does not inlucde the *output_dir* or the .md extension.
 The end of a markdown section of the input file is indicated by the following
 text:
 <p style="margin-left:10%">
-[end_markdown <i>section_name</i>]
+{end_markdown <i>section_name</i>}
 <p/>
 Here *section_name* must be the same as in the start of this markdown section.
 
@@ -63,7 +63,7 @@ by the same number of space characters, that may space characters
 are not included in the markdown output. This enables one to indent the
 markdown so it is grouped with the proper code block in the soruce.
 
-[end_markdown extract_md]'''
+{end_markdown extract_md}'''
 # ----------------------------------------------------------------------------
 import sys
 import re
@@ -94,8 +94,8 @@ section_list       = list()
 corresponding_file = list()
 #
 # pattern for start of markdown section
-pattern_begin_markdown = re.compile( '\\[begin_markdown\\s*(\\w*)\\]' )
-pattern_end_markdown   = re.compile( '\\[end_markdown\\s*(\\w*)\\]' )
+pattern_begin_markdown = re.compile( '\\{begin_markdown \\s*(\\w*)\\}' )
+pattern_end_markdown   = re.compile( '\\{end_markdown \\s*(\\w*)\\}' )
 pattern_begin_3quote   = re.compile( '[^\\n]*(```\\s*\\w*)[^\\n]*' )
 pattern_end_3quote     = re.compile( '[^\\n]*(```)[^\\n]*' )
 pattern_newline        = re.compile( '\\n')
@@ -119,7 +119,7 @@ for file_in in file_list :
         if match_begin == None :
             if data_index == 0 :
                 # There is no match for pattern_begin_markdown in this file.
-                msg  = 'can not find: [begin_markdown section_name\]\n'
+                msg  = 'can not find: {begin_markdown section_name\}\n'
                 msg += 'in ' + file_in + '\n'
                 sys_exit(msg)
             data_index = len(file_data)

--- a/example/covariate.py
+++ b/example/covariate.py
@@ -2,6 +2,19 @@
 # vim: set expandtab:
 '''
 {begin_markdown covariate_xam}
+{spell_markdown
+    frac
+    ldots
+    cdot
+    cdots
+    erf
+    mbox
+    params
+    param
+    dtype
+    covs
+    init
+}
 
 # Using Covariates
 
@@ -23,7 +36,7 @@ A grid of *n_data* points in time, \( t_i \), where
     t_i = \beta_T / ( n_D - 1 )
 \]
 where the subscript \( T \) denotes the true value
-of the currespondng parameter and \( n_D \) is the number of data points.
+of the corresponding parameter and \( n_D \) is the number of data points.
 The minimum value for this grid is zero and its maximum is \( \beta \).
 
 ### Measurement values
@@ -78,7 +91,7 @@ A grid of *n_data* points in time, \( t_i \), where
     t_i = b_T / ( n_D - 1 )
 \]
 where the subscript \( T \) denotes the true value
-of the currespondng parameter and \( n_D \) is the number of data points.
+of the corresponding parameter and \( n_D \) is the number of data points.
 The minimum value for this grid is zero and its maximum is \( b_T \).
 
 ### Social Distance

--- a/example/covariate.py
+++ b/example/covariate.py
@@ -14,6 +14,8 @@
     dtype
     covs
     init
+    ftol
+    gtol
 }
 
 # Using Covariates
@@ -203,8 +205,18 @@ fe_init   = fe_true / 3.0
 re_init   = numpy.zeros( num_fe )
 fe_bounds = [ [-numpy.inf, numpy.inf] ] * num_fe
 re_bounds = [ [0.0, 0.0] ] * num_fe
+options   = {
+    'ftol' : 1e-12,
+    'gtol' : 1e-12,
+}
 #
-curve_model.fit_params(fe_init, re_init, fe_bounds, re_bounds)
+curve_model.fit_params(
+    fe_init,
+    re_init,
+    fe_bounds,
+    re_bounds,
+    options=options
+)
 fe_estimate = curve_model.result.x[:num_fe]
 # -------------------------------------------------------------------------
 # check result

--- a/example/covariate.py
+++ b/example/covariate.py
@@ -1,7 +1,7 @@
 #! /bin/python3
 # vim: set expandtab:
 '''
-[begin_markdown covariate_xam]
+{begin_markdown covariate_xam}
 
 # Using Covariates
 
@@ -202,5 +202,5 @@ for i in range(num_fe) :
 print('covariate.py: OK')
 sys.exit(0)
 ''' ```
-[end_markdown covariate_xam]
+{end_markdown covariate_xam}
 '''

--- a/example/get_started.py
+++ b/example/get_started.py
@@ -2,6 +2,17 @@
 # vim: set expandtab:
 '''
 {begin_markdown get_started_xam}
+{spell_markdown
+    frac
+    ldots
+    params
+    covs
+    param
+    inv
+    init
+    finfo
+    py
+}
 
 # Getting Started Using CurveFit
 
@@ -19,7 +30,7 @@ that the solution is correct:
 n_data       = 21    # number simulated measurements to generate
 beta_true    = 20.0             # max death rate at 20 days
 alpha_true   = 2.0 / beta_true  # alpha_true * beta_true = 2.0
-p_true       = 0.1              # maximum cumulaitve death fraction
+p_true       = 0.1              # maximum cumulative death fraction
 rel_tol      = 1e-5  # relative tolerance used to check optimal solution
 '''```
 
@@ -31,7 +42,7 @@ A grid of *n_data* points in time, \( t_i \), where
     t_i = \beta_T / ( n_D - 1 )
 \]
 where the subscript \( T \) denotes the true value
-of the currespondng parameter and \( n_D \) is the number of data points.
+of the corresponding parameter and \( n_D \) is the number of data points.
 The minimum value for this grid is zero and its maximum is \( \beta \).
 
 ### Measurement values
@@ -77,7 +88,6 @@ import numpy
 import sandbox
 sandbox.path()
 import curvefit
-from curvefit.core.model import CurveModel
 #
 # for this model number of parameters is same as number of fixed effects
 num_params   = 3
@@ -148,7 +158,7 @@ curve_model = curvefit.core.model.CurveModel(
 # -------------------------------------------------------------------------
 # fit_params
 #
-# initialize fixed effects so correpsond to true parameters divided by three
+# initialize fixed effects so correspond to true parameters divided by three
 inv_link_fun = [ log_fun, identity_fun, log_fun ]
 fe_init      = numpy.zeros( num_fe )
 for i in range(num_fe) :

--- a/example/get_started.py
+++ b/example/get_started.py
@@ -12,6 +12,8 @@
     init
     finfo
     py
+    ftol
+    gtol
 }
 
 # Getting Started Using CurveFit
@@ -167,8 +169,18 @@ for i in range(num_fe) :
 re_init   = numpy.zeros( num_fe )
 fe_bounds = [ [-numpy.inf, numpy.inf] ] * num_fe
 re_bounds = [ [0.0, 0.0] ] * num_fe
+options={
+    'ftol' : 1e-12,
+    'gtol' : 1e-12,
+}
 #
-curve_model.fit_params(fe_init, re_init, fe_bounds, re_bounds)
+curve_model.fit_params(
+    fe_init,
+    re_init,
+    fe_bounds,
+    re_bounds,
+    options=options
+)
 params_estimate = curve_model.params
 fe_estimate     = curve_model.result.x[: num_fe]
 # -------------------------------------------------------------------------

--- a/example/get_started.py
+++ b/example/get_started.py
@@ -1,7 +1,7 @@
 #! /bin/python3
 # vim: set expandtab:
 '''
-[begin_markdown get_started_xam]
+{begin_markdown get_started_xam}
 
 # Getting Started Using CurveFit
 
@@ -175,5 +175,5 @@ for i in range(num_params) :
 print('get_started.py: OK')
 sys.exit(0)
 ''' ```
-[end_markdown get_started_xam]
+{end_markdown get_started_xam}
 '''

--- a/example/sizes_to_indices.py
+++ b/example/sizes_to_indices.py
@@ -1,4 +1,5 @@
 '''{begin_markdown sizes_to_indices_xam}
+{spell_markdown utils}
 
 # Example and Test of sizes_to_indices
 

--- a/example/sizes_to_indices.py
+++ b/example/sizes_to_indices.py
@@ -1,4 +1,4 @@
-'''[begin_markdown sizes_to_indices_xam]
+'''{begin_markdown sizes_to_indices_xam}
 
 # Example and Test of sizes_to_indices
 
@@ -17,4 +17,4 @@ assert all( indices[2] == numpy.array([6, 7, 8]) )
 print('sizes_to_indices.py: OK')
 sys.exit(0)
 '''```
-[end_markdown sizes_to_indices_xam]'''
+{end_markdown sizes_to_indices_xam}'''

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,12 +4,6 @@ nav:
   - Methods: 'methods.md'
   - Code: 'code.md'
   - Release Notes: 'updates.md'
-  - Extracted Doc:
-    - get_started_xam: 'extract_md/get_started_xam.md'
-    - covariate_xam: 'extract_md/covariate_xam.md'
-    - sizes_to_indices_xam: 'extract_md/sizes_to_indices_xam.md'
-    - sizes_to_indices: 'extract_md/sizes_to_indices.md'
-    - extract_md: 'extract_md/extract_md.md'
 theme:
     name: 'material'
     palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,12 @@ nav:
   - Methods: 'methods.md'
   - Code: 'code.md'
   - Release Notes: 'updates.md'
+  - Extracted Doc:
+    - get_started_xam: 'extract_md/get_started_xam.md'
+    - covariate_xam: 'extract_md/covariate_xam.md'
+    - sizes_to_indices_xam: 'extract_md/sizes_to_indices_xam.md'
+    - sizes_to_indices: 'extract_md/sizes_to_indices.md'
+    - extract_md: 'extract_md/extract_md.md'
 theme:
     name: 'material'
     palette:

--- a/src/curvefit/core/model.py
+++ b/src/curvefit/core/model.py
@@ -369,7 +369,6 @@ class CurveModel:
             jac=self.gradient,
             method='L-BFGS-B',
             bounds=bounds,
-            tol=1e-12,
             options=options
         )
 

--- a/src/curvefit/core/utils.py
+++ b/src/curvefit/core/utils.py
@@ -8,6 +8,7 @@ from curvefit.core.functions import *
 
 def sizes_to_indices(sizes):
     """{begin_markdown sizes_to_indices}
+    {spell_markdown subvector subvectors xam}
     # Converting sizes to corresponding indices.
 
     ## Syntax

--- a/src/curvefit/core/utils.py
+++ b/src/curvefit/core/utils.py
@@ -7,7 +7,7 @@ from curvefit.core.functions import *
 
 
 def sizes_to_indices(sizes):
-    """[begin_markdown sizes_to_indices]
+    """{begin_markdown sizes_to_indices}
     # Converting sizes to corresponding indices.
 
     ## Syntax
@@ -28,7 +28,7 @@ def sizes_to_indices(sizes):
     ## Example
     [sizes_to_indices_xam](sizes_to_indices_xam.md)
 
-    [end_markdown sizes_to_indices]"""
+    {end_markdown sizes_to_indices}"""
     indices = []
     a = 0
     b = 0


### PR DESCRIPTION
I added spell checking to extract_md.py; see the heading Spell Checking on
https://bradbell.github.io/CurveFit/extract_md/extract_md/
and then fixed a lot of spelling errors in my examples.

I also backed out the setting of the tolerance in model.py and moved the necessary tolerances to the `options` argument to `fit_params` in the get_started and covariate examples.
