### PR TITLE
Update examples and documentation with new variable names

### DIFF
--- a/docs/code.md
+++ b/docs/code.md
@@ -25,16 +25,21 @@ represent what and some model parameters.
 - `param_names (list{str})`: names of the parameters for your specific functional form (more in [functions](#functions))
 - `link_fun (list{function})`: list of link functions for each of the parameters
 - `var_link_fun (list{function})`: list of functions for the variables including fixed and random effects
+- `fun {function}`: the function to fit (see [functions](#functions))
 
 Here is an example of creating a `CurveModel` with a data frame where `time` is the independent variable,
 `death_rate` is the dependent variable, and `group` is a variable indicating which group an observation belongs to.
-In this example, we want to fit to the log erf functional form (see [functions](#functions)) with
+In this example, we want to fit to the `ln_gaussian_cdf` functional form (see [functions](#functions)) with
 identity link functions for each parameter and identity variable link functions for each parameter.
 In this example, no parameters have covariates besides an intercept column of 1's.
 
 ```python
+import pandas as pd
 from curvefit.core.model import CurveModel
-from curvefit.core.functions import log_erf
+from curvefit.core.functions import ln_gaussian_cdf
+
+df = pd.read_csv('my_data.csv')
+df['intercept'] = 1
 
 model = CurveModel(
     df=df,
@@ -45,7 +50,7 @@ model = CurveModel(
     param_names=['alpha', 'beta', 'p'],
     link_fun=[lambda x: x, lambda x: x, lambda x: x],
     var_link_fun=[lambda x: x, lambda x: x, lambda x: x],
-    fun=log_erf
+    fun=ln_gaussian_cdf
 )
 ```
 
@@ -60,15 +65,15 @@ The available built-in functions in `curvefit.functions` are:
 
 **The Error Function**
 
-- `erf`: error function (Gauss error function)
-- `derf`: derivative of the error function
-- `log_erf`: log error function
-- `log_derf`: log derivative of the erf function
+- `gaussian_cdf`: error function (Gauss error function)
+- `gaussian_pdf`: derivative of the error function
+- `ln_gaussian_cdf`: log error function
+- `ln_gaussian_pdf`: log derivative of the error function
 
 **The Expit Function** (inverse of the logit function)
 
 - `expit`: expit function
-- `log_expit`: log expit function
+- `ln_expit`: log expit function
 
 Please see the [functions](methods.md#covid-19-functional-forms) for information
 about the parametrization of these functions and how they relate to COVID-19 modeling.

--- a/example/param_time_fun.py
+++ b/example/param_time_fun.py
@@ -41,42 +41,42 @@ check     = eval_expit(t, alpha, beta, p)
 rel_error = value / check - 1.0
 assert all( abs( rel_error ) < eps99 )
 #
-# check log_expit
-value     = curvefit.core.functions.log_expit(t, params)
+# check ln_expit
+value     = curvefit.core.functions.ln_expit(t, params)
 check     = numpy.log(check)
 rel_error = value / check - 1.0
 assert all( abs( rel_error ) < eps99 )
 #
-# check erf
-value     = curvefit.core.functions.erf(t, params)
+# check gaussian_cdf
+value     = curvefit.core.functions.gaussian_cdf(t, params)
 check     = eval_erf(t, alpha, beta, p)
 rel_error = value / check - 1.0
 assert all( abs( rel_error ) < eps99 )
 #
-# check log_erf
-value     = curvefit.core.functions.log_erf(t, params)
+# check ln_gaussian_cdf
+value     = curvefit.core.functions.ln_gaussian_cdf(t, params)
 check     = numpy.log(check)
 rel_error = value / check - 1.0
 assert all( abs( rel_error ) < eps99 )
 #
-# check derf
+# check gaussian_pdf
 step      = sqrt_eps * beta
-value     = curvefit.core.functions.derf(t, params)
+value     = curvefit.core.functions.gaussian_pdf(t, params)
 check_m   = eval_erf(t - step, alpha, beta, p)
 check_p   = eval_erf(t + step, alpha, beta, p)
 check     = (check_p - check_m) / (2.0 * step)
 rel_error = value / check - 1.0
 assert all( abs( rel_error ) < d_tolerance )
 #
-# check log_derf
-value     = curvefit.core.functions.log_derf(t, params)
+# check ln_gaussian_pdf
+value     = curvefit.core.functions.ln_gaussian_pdf(t, params)
 check     = numpy.log(check)
 rel_error = value / check - 1.0
 assert all( abs( rel_error ) < d_tolerance )
 #
-# check_dderf
+# check dgaussian_pdf
 step      = quad_eps * beta
-value     = curvefit.core.functions.dderf(t, params)
+value     = curvefit.core.functions.dgaussian_pdf(t, params)
 check_m   = eval_erf(t - step, alpha, beta, p)
 check_0   = eval_erf(t,        alpha, beta, p)
 check_p   = eval_erf(t + step, alpha, beta, p)


### PR DESCRIPTION
I realized one example and the docs still had the old variable names.