### PR TITLE
Prior Initializer + Prototype + ParameterFunction

### DIFF
--- a/bin/extract_md.py
+++ b/bin/extract_md.py
@@ -30,15 +30,21 @@ file_list = [
 ]
 # list of extra words that the spell checker will consider correct
 extra_special_words = [
+    'bool',
     'covariates',
     'covariate',
     'curvefit',
     'curvemodel',
     'dict',
     'dtype',
+    'gprior'
+    'init',
+    'inits',
     'initialized',
     'initialize',
     'numpy',
+    'ndarray',
+    'param',
     'params',
     'py',
     'sandbox',

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
     - core:
         - data:
             - Data: 'extract_md/Data.md'
+            - DataSpecs: 'extract_md/DataSpecs.md'
         - parameter:
             - Variable: 'extract_md/Variable.md'
             - Parameter: 'extract_md/Parameter.md'
@@ -20,6 +21,9 @@ nav:
         - residual models:
             - _ResidualModel: 'extract_md/_ResidualModel.md'
             - SmoothResidualModel: 'extract_md/SmoothResidualModel.md'
+        - effects2params:
+            - unzip_x: 'extract_md/unzip_x.md'
+            - effects2params: 'extract_md/effects2params.md'
     - models:
         - core_model:
             - DataInputs: 'extract_md/DataInputs.md'
@@ -31,11 +35,9 @@ nav:
             - convolve_sum: 'extract_md/convolve_sum.md'
             - df_to_mat: 'extract_md/df_to_mat.md'
     - other:
-      - unzip_x: 'extract_md/unzip_x.md'
       - sizes_to_indices: 'extract_md/sizes_to_indices.md'
       - split_by_group: 'extract_md/split_by_group.md'
       - param_time_fun: 'extract_md/param_time_fun.md'
-      - effects2params: 'extract_md/effects2params.md'
       - objective_fun: 'extract_md/objective_fun.md'
       - extract_md.py: 'extract_md/extract_md.py.md'
       - get_cppad_py.py: 'extract_md/get_cppad_py.py.md'

--- a/src/curvefit/core/__init__.py
+++ b/src/curvefit/core/__init__.py
@@ -1,1 +1,1 @@
-
+from . import model

--- a/src/curvefit/core/__init__.py
+++ b/src/curvefit/core/__init__.py
@@ -1,1 +1,1 @@
-from . import model
+

--- a/src/curvefit/core/data.py
+++ b/src/curvefit/core/data.py
@@ -86,7 +86,6 @@ class Data:
             col_obs=self.col_obs,
             col_covs=self.col_covs,
             col_group=self.col_group,
-            col_obs_se=self.col_obs_se,
             obs_space=self.obs_space,
             obs_se_fun=self.obs_se_func
         )

--- a/src/curvefit/core/data.py
+++ b/src/curvefit/core/data.py
@@ -6,6 +6,18 @@ from curvefit.utils.data import data_translator
 
 @dataclass(frozen=True)
 class DataSpecs:
+    """
+    {begin_markdown DataSpecs}
+
+    # `curvefit.core.data.DataSpecs`
+    ## Data specifications based on a `Data` object
+
+    ## Arguments
+
+    See arguments to [`curvefit.core.data.Data`](Data.md).
+
+    {end_markdown DataSpecs}
+    """
     col_t: str
     col_obs: str
     col_covs: List[str]
@@ -56,8 +68,9 @@ class Data:
     ## Methods
 
     ### `get_df`
-    Returns a copy of the data frame, or a pointer to the data frame. If you plan on modifying the data frame,
-    use `copy=True`. If a group is passed, then a group-specific data frame will be passed.
+    Returns a copy of the data frame or a pointer to the data frame, and optionally data specs.
+    If you plan on modifying the data frame, use `copy=True`. If a group is passed,
+    then a group-specific data frame will be passed.
 
     - `group (optional, str)`: optional group name
     - `copy (bool)`: return a copy or not
@@ -80,15 +93,7 @@ class Data:
         self.col_group = col_group
         self.obs_space = obs_space
         self.obs_se_func = obs_se_func
-
-        self.data_specs = DataSpecs(
-            col_t=self.col_t,
-            col_obs=self.col_obs,
-            col_covs=self.col_covs,
-            col_group=self.col_group,
-            obs_space=self.obs_space,
-            obs_se_fun=self.obs_se_func
-        )
+        self.col_obs_se = col_obs_se
 
         self.df.sort_values([self.col_group, self.col_t], inplace=True)
 
@@ -97,6 +102,16 @@ class Data:
             self.df[self.col_obs_se] = self.df[self.col_t].apply(self.obs_se_func)
         else:
             self.col_obs_se = col_obs_se
+
+        self.data_specs = DataSpecs(
+            col_t=self.col_t,
+            col_obs=self.col_obs,
+            col_covs=self.col_covs,
+            col_group=self.col_group,
+            obs_space=self.obs_space,
+            obs_se_fun=self.obs_se_func,
+            col_obs_se=self.col_obs_se
+        )
 
         self.groups = self.df[self.col_group].unique()
 

--- a/src/curvefit/core/data.py
+++ b/src/curvefit/core/data.py
@@ -3,6 +3,7 @@ from typing import List
 
 from curvefit.utils.data import data_translator
 
+
 @dataclass(frozen=True)
 class DataSpecs:
     col_t: str
@@ -80,7 +81,15 @@ class Data:
         self.obs_space = obs_space
         self.obs_se_func = obs_se_func
 
-        self.data_specs = DataSpecs(col_t, col_obs, col_covs, col_group, col_obs_se, obs_space, obs_se_func)
+        self.data_specs = DataSpecs(
+            col_t=self.col_t,
+            col_obs=self.col_obs,
+            col_covs=self.col_covs,
+            col_group=self.col_group,
+            col_obs_se=self.col_obs_se,
+            obs_space=self.obs_space,
+            obs_se_fun=self.obs_se_func
+        )
 
         self.df.sort_values([self.col_group, self.col_t], inplace=True)
 

--- a/src/curvefit/core/effects2params.py
+++ b/src/curvefit/core/effects2params.py
@@ -1,170 +1,164 @@
 import numpy
-import curvefit
+from curvefit.core.utils import sizes_to_indices
 
-def unzip_x(x, num_groups, num_fe) :
-    '''{begin_markdown unzip_x}
+
+def unzip_x(x, num_groups, num_fe):
+    """
+    {begin_markdown unzip_x}
     {spell_markdown params}
 
-    # Extract Fixed and Random Effects from Single Vector Form
+    # `curvefit.core.effects2params.unzip_x`
+    ## Extract Fixed and Random Effects from Single Vector Form
 
     ## Syntax
-    `fe, re = curvefit.core.effects2params.unzip_x(x, num_groups, num_fe)`
 
-    ## num_groups
-    is the number of data groups.
-
-    ## num_fe
-    is the number of fixed effects.
-
-    ## x
-    is a numpy vector with length equal to `(num_groups + 1)*num_fe`
-
-    ## fe
-    this return value
-    is a numpy vector containing the fist *num_fe* elements of *x*.
-
-    ## re
-    this return value
-    is a numpy two dimensional array with row dimension *num_groups*
-    and column dimension *num_fe*.
-    The i-th row of *re* contains the following sub-vector of *x*
     ```python
-        re[i,:] = x[(i+1)*num_fe : (i+2)*num_fe]
+    fe, re = curvefit.core.effects2params.unzip_x(x, num_groups, num_fe)
     ```
+
+    ## Arguments
+
+    - `x (np.array)`: a numpy vector with length equal to
+        `(num_groups + 1) * num_fe`
+    - `num_groups (int)`: is the number of data groups
+    - `num_fe (int)`: is the number of fixed effects
+
+    ## Returns
+
+    - `fe (np.array)`: is a numpy vector containing the fist *num_fe* elements of *x*.
+    - `re (np.array)`: is a numpy two dimensional array with row dimension *num_groups*
+        and column dimension *num_fe*. The i-th row of *re* contains the following sub-vector of *x*
+        ```python
+            re[i,:] = x[(i+1)*num_fe : (i+2)*num_fe]
+        ```
 
     ## Example
     [unzip_x_xam](unzip_x_xam.md)
 
-    {end_markdown unzip_x}'''
+    {end_markdown unzip_x}
+    """
     fe = x[: num_fe]
-    re = x[num_fe :].reshape(num_groups, num_fe, order='C')
+    re = x[num_fe:].reshape(num_groups, num_fe, order='C')
     return fe, re
 
-def effects2params(x, group_sizes, covs, link_fun, var_link_fun, expand=True) :
-    '''{begin_markdown effects2params}
+
+def effects2params(x, group_sizes, covs, link_fun, var_link_fun, expand=True):
+    """
+    {begin_markdown effects2params}
     {spell_markdown params covs}
 
-    # Map Vector of Fixed and Random Effects to Parameter Matrix
+    # `curvefit.core.effects2params`
+    ## Map Vector of Fixed and Random Effects to Parameter Matrix
 
     ## Syntax
-    `params = curvefit.core.effects2params.effects2params(
+    ```python
+    params = curvefit.core.effects2params.effects2params(
         x, group_sizes, covs, link_fun, var_link_fun, expand=True
-    )`
+    )
+    ```
 
-    ## Vector
-    If `v` is a vector, `len(v)` is its length as an integer. For non-negative
-    integer `i` less than `len(v)`, and `v[i]` is its i-th element.
+    ## Arguments
 
-    ## group_sizes
-    is a vector of positive integers.
-    The first `group_sizes[0]` observations correspond to the first group,
-    the next `group_sizes[1]` corresponds to the section group, and so on.
-    The total number of observations is the sum of the group sizes.
+    - `x (np.array)`:
+        This is a one dimensional numpy array contain a value for the fixed effects
+        followed by the random effects. The random effects are divided into
+        sub-vectors with length equal to the number of fixed effects.
+        The i-th sub-vector corresponds to the i-th group of observations.
+    - `group_sizes (array-like)`: A vector of positive integers.
+        The first `group_sizes[0]` observations correspond to the first group,
+        the next `group_sizes[1]` corresponds to the section group, and so on.
+        The total number of observations is the sum of the group sizes.
+    - `covs (List[np.ndarray])`: Is a `list` with length equal to the number
+        of parameters and `covs[k]` is a two dimensional numpy array with the following contents:
+        -- `covs[k].shape[0]` is the number of observations
+        -- `covs[k].shape[1]` is the number of fixed effects corresponding to the
+        k-th parameter.
+        -- `covs[k][i, ell]` is the covariate value corresponding to the
+        i-th observation and ell-th covariate for the k-th parameter.
+    - `link_fun` (List[Callable])`: The value `len(link_fun)` is equal to the
+        number of parameters and `link_fun[k]` is a function with one
+         numpy array argument and result that acts element by element and transforms the k-th parameter.
+    - `var_link_fun` (List[Callable])`:
+        The value `len(var_link_fun)` is equal to the number of fixed effects and
+        `link_fun[j]` is a function with one numpy array argument and result that
+        that acts element by element and transforms the j-th fixed effect.
+        The first `len(covs[0])` fixed effects correspond to the first parameter,
+        the next `len(covs[1])` fixed effects correspond to the second parameter
+        and so on.
+    - `expand (bool)`:  If *expand* is `True` (`False`), create
+        parameters for each observation (for each group of observations).
 
-    ## covs
-    Is a `list` with length equal to the number of parameters and `covs[k]`
-    is a two dimensional numpy array with the following contents:
+    ## Returns
 
-    -- `covs[k].shape[0]` is the number of observations
-
-    -- `covs[k].shape[1]` is the number of fixed effects corresponding to the
-    k-th parameter.
-
-    -- `covs[k][i, ell]` is the covariate value corresponding to the
-    i-th observation and ell-th covariate for the k-th parameter.
-
-    ## link_fun
-    The value `len(link_fun)` is equal to the number of parameters and
-    `link_fun[k]` is a function with one numpy array argument and result
-    that acts element by element and transforms the k-th parameter.
-
-    ## var_link_fun
-    The value `len(var_link_fun)` is equal to the number of fixed effects and
-    `link_fun[j]` is a function with one numpy array argument and result that
-    that acts element by element and transforms the j-th fixed effect.
-    The first `len(covs[0])` fixed effects correspond to the first parameter,
-    the next `len(covs[1])` fixed effects correspond to the second parameter
-    and so on.
-
-    ## expand
-    If *expand* is `True` (`False`), create parameters for each observation
-    (for each group of observations).
-
-    ## x
-    This is a one dimensional numpy array contain a value for the fixed effects
-    followed by the random effects. The random effects are divided into
-    sub-vectors with length equal to the number of fixed effects.
-    The i-th sub-vector corresponds to the i-th group of observations.
-
-    ## params
-    Let \( f_j \) be the vector of fixed effects and
-    \( r_{i,j} \) the matrix of random effects corresponding to *x*.
-    We define the matrix, with row dimension equal the number of groups
-    and column dimension equal the number of fixed effects
-    \[
-        v_{i,j} = V_j \left( f_j + r_{i,j} \right)
-    \]
-    where \( V_j \) is the function `var_link_fun[i]`.
-    If *expand* is true (false) \( i \) indexes observations (groups).
-    (If *expand* is true the random effect for a group gets repeated
-    for all the observations in the group.)
-    The return value `params` is a two dimensional numpy array with
-    `params.shape[0]` equal to the number of parameters and
-    `params.shape[1]` equal to the number of observations, if *expand* is true,
-    number of groups, if *expand* is false.
-    The value `params[k][i]` is
-    \[
-        P_k \left( \sum_{j(k)} v_j c_{i,j} \right)
-    \]
-    where \( P_k \) is the function `link_fun[k]`,
-    \( j(k) \) is the set of fixed effects indices
-    corresponding to the k-th parameter,
-    \( c_{i,j} \) is the covariate value corresponding to the
-    j-th fixed effect and the i-th observation, if *expand* is true,
-    or i-th group, if *expand* is false.
+    - `params (array-like)`:
+        Let \( f_j \) be the vector of fixed effects and
+        \( r_{i,j} \) the matrix of random effects corresponding to *x*.
+        We define the matrix, with row dimension equal the number of groups
+        and column dimension equal the number of fixed effects
+        \[
+            v_{i,j} = V_j \left( f_j + r_{i,j} \right)
+        \]
+        where \( V_j \) is the function `var_link_fun[i]`.
+        If *expand* is true (false) \( i \) indexes observations (groups).
+        (If *expand* is true the random effect for a group gets repeated
+        for all the observations in the group.)
+        The return value `params` is a two dimensional numpy array with
+        `params.shape[0]` equal to the number of parameters and
+        `params.shape[1]` equal to the number of observations, if *expand* is true,
+        number of groups, if *expand* is false.
+        The value `params[k][i]` is
+        \[
+            P_k \left( \sum_{j(k)} v_j c_{i,j} \right)
+        \]
+        where \( P_k \) is the function `link_fun[k]`,
+        \( j(k) \) is the set of fixed effects indices
+        corresponding to the k-th parameter,
+        \( c_{i,j} \) is the covariate value corresponding to the
+        j-th fixed effect and the i-th observation, if *expand* is true,
+        or i-th group, if *expand* is false.
 
     ## Example
-    [effects2params_xam](effects2params_xam.md)
+    See [effects2params_xam](effects2params_xam.md).
 
-    {end_markdown effects2params}'''
-    num_obs    = numpy.sum(group_sizes)
+    {end_markdown effects2params}
+    """
+    num_obs = numpy.sum(group_sizes)
     num_groups = len(group_sizes)
     num_params = len(covs)
-    group_idx  = numpy.cumsum(group_sizes) - 1
-    fe_sizes   = numpy.array([ covs[k].shape[1] for k in range(num_params) ])
-    num_fe     = fe_sizes.sum()
-    num_re     = num_groups * num_fe
-    fe_idx     = curvefit.core.utils.sizes_to_indices(fe_sizes)
-    #
+    group_idx = numpy.cumsum(group_sizes) - 1
+    fe_sizes = numpy.array([covs[k].shape[1] for k in range(num_params)])
+    num_fe = fe_sizes.sum()
+    num_re = num_groups * num_fe
+    fe_idx = sizes_to_indices(fe_sizes)
+
     # asserts
-    for k in range(num_params) :
+    for k in range(num_params):
         assert covs[k].shape[0] == num_obs
     assert len(link_fun) == num_params
-    #
-    #
+
     # unpack fe and re from x
-    fe, re   = unzip_x(x, num_groups, num_fe)
-    if expand :
+    fe, re = unzip_x(x, num_groups, num_fe)
+    if expand:
         # expand random effects
         re = numpy.repeat(re, group_sizes, axis=0)
-    else :
+    else:
         # subsample covariates
-        covs = [ covs[k][group_idx,:] for k in range(num_params) ]
-    #
+        covs = [covs[k][group_idx, :] for k in range(num_params)]
+
     # var  = var_link_fun( fe + re )
     var = fe + re
-    for j in range(num_fe) :
-        var[:, j] = var_link_fun[j]( var[:, j] )
-    #
+    for j in range(num_fe):
+        var[:, j] = var_link_fun[j](var[:, j])
+
     # params[k][i] = link_fun[k] ( sum_{j(k)} covs[j, i] * var[i, j] )
-    shape  = (num_params, num_obs) if expand else (num_params, num_groups)
-    params = numpy.empty( shape, dtype = type(x[0]) )
-    for k in range(num_params) :
+    shape = (num_params, num_obs) if expand else (num_params, num_groups)
+    params = numpy.empty(shape, dtype=type(x[0]))
+    for k in range(num_params):
         # covariate times variable for i-th parameter
-        prod      = covs[k] * var[:, fe_idx[k]]
+        prod = covs[k] * var[:, fe_idx[k]]
         # sum of produces for i-th parameter
         params[k] = numpy.sum(prod, axis=1)
         # transform the sum
-        params[k] = link_fun[k]( params[k] )
-    #
+        params[k] = link_fun[k](params[k])
+
     return params

--- a/src/curvefit/core/effects2params.py
+++ b/src/curvefit/core/effects2params.py
@@ -50,6 +50,9 @@ def effects2params(x, group_sizes, covs, link_fun, var_link_fun, expand=True):
     # `curvefit.core.effects2params`
     ## Map Vector of Fixed and Random Effects to Parameter Matrix
 
+    Extracts fixed and random effects and converts them to parameters.
+    Needs to use [`unzip_x`](unzip_x.md).
+
     ## Syntax
     ```python
     params = curvefit.core.effects2params.effects2params(
@@ -128,7 +131,6 @@ def effects2params(x, group_sizes, covs, link_fun, var_link_fun, expand=True):
     group_idx = numpy.cumsum(group_sizes) - 1
     fe_sizes = numpy.array([covs[k].shape[1] for k in range(num_params)])
     num_fe = fe_sizes.sum()
-    num_re = num_groups * num_fe
     fe_idx = sizes_to_indices(fe_sizes)
 
     # asserts

--- a/src/curvefit/core/parameter.py
+++ b/src/curvefit/core/parameter.py
@@ -162,7 +162,7 @@ class ParameterSet(Prototype):
     """
     {begin_markdown ParameterSet}
 
-    {spell_markdown init inits param params}
+    {spell_markdown init inits param params gprior}
 
     # `curvefit.core.parameter.ParameterSet`
     ## A set of parameters that together specify the functional form of a curve

--- a/src/curvefit/core/parameter.py
+++ b/src/curvefit/core/parameter.py
@@ -145,7 +145,7 @@ class Parameter:
 
 
 @dataclass
-class ParameterFunction(Prototype):
+class ParameterFunction:
 
     param_function_name: str
     param_function: Callable

--- a/src/curvefit/core/prototype.py
+++ b/src/curvefit/core/prototype.py
@@ -1,0 +1,26 @@
+from copy import deepcopy
+
+
+class Prototype:
+    """
+    {begin_markdown Prototype}
+
+    {spell_markdown deepcopy}
+
+    # `curvefit.core.prototype.Prototype`
+    ## Base class for an object that can be cloned
+
+    Some objects in the `curvefit` package need to be treated as prototypes and cloned.
+    If an object needs this ability, it will be a subclass of `Prototype` and inherit the `clone` method.
+
+    ## Methods
+
+    ### `clone`
+    Returns a deepcopy of itself.
+
+    {end_markdown Prototype}
+    """
+
+    def clone(self):
+        return deepcopy(self)
+

--- a/src/curvefit/initializer/initializer.py
+++ b/src/curvefit/initializer/initializer.py
@@ -306,7 +306,7 @@ class PriorInitializer:
 
         for group in data.groups:
             model = model_prototype.clone()
-            solver = solver_prototype.cone()
+            solver = solver_prototype.clone()
 
             group_data = data.get_df(group=group, copy=False, return_specs=True)
 

--- a/src/curvefit/initializer/initializer.py
+++ b/src/curvefit/initializer/initializer.py
@@ -2,6 +2,7 @@ import numpy as np
 from typing import List
 
 from curvefit.solvers.solvers import Solver
+from curvefit.core.effects2params import effects2params
 
 
 class PriorInitializerComponent:

--- a/src/curvefit/initializer/initializer.py
+++ b/src/curvefit/initializer/initializer.py
@@ -1,0 +1,141 @@
+import numpy as np
+from typing import List
+
+from curvefit.solvers.solvers import Solver
+
+
+class PriorInitializerComponent:
+    def __init__(self):
+        self.initializer_type = None
+
+    def _extract_prior(self, solver):
+        pass
+
+    def _update_parameter_set(self, parameter_set_prototype, solvers):
+        pass
+
+
+class JointPriorInitializerComponent(PriorInitializerComponent):
+    def __init__(self):
+        super().__init__()
+        self.initializer_type = 'joint'
+
+
+class IndividualPriorInitializerComponent(PriorInitializerComponent):
+    def __init__(self):
+        super().__init__()
+        self.initializer_type = 'individual'
+
+
+class LnAlphaBetaPrior(IndividualPriorInitializerComponent):
+    def __init__(self):
+        super().__init__()
+
+    def _extract_prior(self, solver):
+        assert isinstance(solver, List)
+        pass
+
+    def _update_parameter_set(self, parameter_set_prototype, solvers):
+        param_set = parameter_set_prototype.clone()
+
+        # Check that the alpha-beta parameter exists
+        param_function_index = param_set.get_param_function_index('ln-alpha-beta')
+
+        # Extract the ln-alpha-beta prior
+        prior = self._extract_prior(solver=solvers)
+        param_set.param_function_fe_gprior[param_function_index] = prior
+
+        return param_set
+
+
+class BetaPrior(JointPriorInitializerComponent):
+    def __init__(self):
+        super().__init__()
+
+    def _extract_prior(self, solver):
+        assert isinstance(solver, Solver)
+        pass
+
+    def _update_parameter_set(self, parameter_set_prototype, solvers):
+        param_set = parameter_set_prototype.clone()
+
+        # Check that the beta parameter exists and only has one variable
+        param_index = param_set.get_param_index(param_name='beta')
+        assert len(param_set.fe_gprior[param_index]) == 1
+
+        # Extract the beta prior from the individual solvers
+        prior = self._extract_prior(solver=solvers)
+        param_set.fe_gprior[param_index] = prior
+        param_set.__post__init()
+
+        return param_set
+
+
+class PriorInitializer:
+    def __init__(self, prior_initializer_instances):
+
+        self.prior_initializer_instances = prior_initializer_instances
+        self.initializer_types = [c.initializer_type for c in self.prior_initializer_instances]
+
+        self.joint_solver = None
+        self.individual_solvers = None
+
+    @staticmethod
+    def run_joint(data, model_prototype, solver_prototype):
+        model = model_prototype.clone()
+        solver = solver_prototype.clone()
+
+        solver.set_model_instance(model)
+        solver.fit(data=data)
+        return solver
+
+    @staticmethod
+    def run_individual(data, model_prototype, solver_prototype):
+        solvers = {}
+
+        for group in data.groups:
+            model = model_prototype.clone()
+            solver = solver_prototype.cone()
+
+            group_data = data.get_df(group=group, copy=False, return_specs=True)
+
+            solver.set_model_instance(model)
+            solver.fit(data=group_data)
+
+            solvers[group] = solver
+
+        return solvers
+
+    def initialize(self, data, model_prototype, solver_prototype, parameter_set_prototype):
+
+        if 'individual' in self.initializer_types:
+            self.individual_solvers = self.run_individual(
+                data, model_prototype=model_prototype,
+                solver_prototype=solver_prototype
+            )
+        if 'joint' in self.initializer_types:
+            self.joint_solver = self.run_joint(
+                data, model_prototype=model_prototype,
+                solver_prototype=solver_prototype
+            )
+
+        param_set = parameter_set_prototype.clone()
+
+        for initializer in self.prior_initializer_instances:
+            if initializer.initializer_type == 'joint':
+                param_set = initializer._update_parameter_set(
+                    solvers=self.joint_solver,
+                    parameter_set_prototype=param_set
+                )
+            elif initializer.initializer_type == 'individual':
+                param_set = initializer._update_parameter_set(
+                    solvers=self.individual_solvers,
+                    parameter_set_prototype=param_set
+                )
+
+        return param_set
+
+
+
+
+

--- a/src/curvefit/initializer/initializer.py
+++ b/src/curvefit/initializer/initializer.py
@@ -2,60 +2,214 @@ import numpy as np
 from typing import List
 
 from curvefit.solvers.solvers import Solver
-from curvefit.core.effects2params import effects2params
+from curvefit.core.effects2params import unzip_x
 
 
 class PriorInitializerComponent:
+    """
+    {begin_markdown PriorInitializerComponent}
+
+    # `curvefit.initializer.initializer.PriorInitializerComponent`
+    ## A component of a prior initializer for a model
+
+    For a given solver, model and parameter set there are a number of strategies to get
+    information to inform a prior for a later model fit. This base class is used to build
+    prior initializer components, that is, objects that extract information from models that have already been run
+    to get well-informed priors for later runs.
+
+    Prior initializer components can have two types: priors that are extracted from the analysis of a joint model run
+    (one model run with > 1 group), and priors that are extracted from the analysis of a bunch of
+    individual models runs (many models runs with 1 group each). See the documentation on
+    [`JointPriorInitializerComponent`](JointPriorInitializerComponent.md) and
+    [`IndividualPriorInitializerComponent`](IndividualPriorInitializerComponent.md).
+
+    ## Attributes
+
+    - `self.component_type (str, None)`: type of component, overridden in subclasses ("joint" or "individual")
+
+    ## Methods
+
+    ### `_extract_prior`
+    A method to extract prior information from a solver or a list of solvers. Overridden in subclasses.
+
+    - `solver (List[Solver], curvefit.core.solver.Solver)`: solver or list of
+        solvers that have fit models to data using a parameter set
+
+    ### `_update_parameter_set`
+    A method to update a parameter set given information that was extracted about the priors from the solvers.
+
+    - `solver (List[Solver], curvefit.core.solver.Solver)`: see above
+    - `parameter_set_prototype (curvefit.core.parameter.ParameterSet)`: a parameter set that will be updated
+        with new prior information
+
+    {end_markdown PriorInitializerComponent}
+    """
     def __init__(self):
-        self.initializer_type = None
+        self.component_type = None
 
     def _extract_prior(self, solver):
         pass
 
-    def _update_parameter_set(self, parameter_set_prototype, solvers):
+    def _update_parameter_set(self, parameter_set_prototype, solver):
         pass
 
 
 class JointPriorInitializerComponent(PriorInitializerComponent):
+    """
+    {begin_markdown JointPriorInitializerComponent}
+
+    # `curvefit.initializer.initializer.JointPriorInitializerComponent`
+    ## A joint prior initializer component for an initializer for a model
+
+    See [`PriorInitializerComponent`](PriorInitializerComponent.md).
+
+    ## Attributes
+
+    - `self.component_type (str)`: "joint", which is the type of component
+
+    ## Methods
+
+    See methods for [`PriorInitializerComponent`](PriorInitializerComponent.md).
+
+    {end_markdown PriorInitializerComponent}
+    """
     def __init__(self):
         super().__init__()
         self.initializer_type = 'joint'
 
 
 class IndividualPriorInitializerComponent(PriorInitializerComponent):
+    """
+    {begin_markdown IndividualPriorInitializerComponent}
+
+    # `curvefit.initializer.initializer.IndividualPriorInitializerComponent`
+    ## An individual prior initializer component for an initializer for a model
+
+    See [`PriorInitializerComponent`](PriorInitializerComponent.md).
+
+    ## Attributes
+
+    - `self.component_type (str)`: "individual", which is the type of component
+
+    ## Methods
+
+    See methods for [`PriorInitializerComponent`](PriorInitializerComponent.md).
+
+    {end_markdown IndividualPriorInitializerComponent}
+    """
     def __init__(self):
         super().__init__()
         self.initializer_type = 'individual'
 
 
 class LnAlphaBetaPrior(IndividualPriorInitializerComponent):
+    """
+    {begin_markdown LnAlphaBetaPrior}
+
+    # `curvefit.initializer.initializer.LnAlphaBetaPrior`
+    ## Gets information about a ln alpha-beta prior for model
+
+    See [`PriorInitializerComponent`](PriorInitializerComponent.md) for a description of a prior initializer.
+    This prior initializer component uses group-specific individual
+    model fits with alpha and beta parameters to get information
+    about what the mean and standard deviation for a functional prior on log(alpha * beta) should be. It uses
+    the empirical mean and standard deviation of log(alpha * beta), typically fit on only a subset of groups
+    that have more data and information about what alpha and beta should be.
+
+    **NOTE: Requires 'alpha' and 'beta' parameters in a ParameterSet along with a functional prior
+    called 'ln-alpha-beta'.**
+
+    ## Attributes
+
+    See attributes for [`IndividualPriorInitializerComponent`](IndividualPriorInitializerComponent.md).
+
+    ## Methods
+
+    See methods for [`IndividualPriorInitializerComponent`](IndividualPriorInitializerComponent.md).
+
+    {end_markdown LnAlphaBetaPrior}
+    """
     def __init__(self):
         super().__init__()
 
     def _extract_prior(self, solver):
         assert isinstance(solver, List)
-        pass
 
-    def _update_parameter_set(self, parameter_set_prototype, solvers):
+        alphas = np.array([])
+        betas = np.array([])
+
+        for sol in solver:
+
+            alpha_idx = sol.model.param_set.get_param_index('alpha')
+            beta_idx = sol.model.param_set.get_param_index('beta')
+
+            params = sol.model.get_params(x=sol.x_opt)
+
+            alphas = alphas.append(params[alpha_idx, 0])
+            betas = betas.append(params[beta_idx, 0])
+
+        prior_mean = np.log(alphas * betas).mean()
+        prior_std = np.log(alphas * betas).std()
+
+        return [prior_mean, prior_std]
+
+    def _update_parameter_set(self, parameter_set_prototype, solver):
         param_set = parameter_set_prototype.clone()
 
         # Check that the alpha-beta parameter exists
         param_function_index = param_set.get_param_function_index('ln-alpha-beta')
 
         # Extract the ln-alpha-beta prior
-        prior = self._extract_prior(solver=solvers)
+        prior = self._extract_prior(solver=solver)
         param_set.param_function_fe_gprior[param_function_index] = prior
+        param_set.__post__init()
 
         return param_set
 
 
 class BetaPrior(JointPriorInitializerComponent):
+    """
+    {begin_markdown BetaPrior}
+
+    # `curvefit.initializer.initializer.BetaPrior`
+    ## Gets information about a beta prior for a model
+
+    See [`PriorInitializerComponent`](PriorInitializerComponent.md) for a description of a prior initializer.
+    This prior initializer component uses one joint model fit that has beta as a parameter. Typically this
+    prior is used only on a subset of groups that have more information about what beta should be.
+    This prior initializer component uses the fixed effect mean as the new prior mean and the standard
+    deviation of the random effects as the prior standard deviation for beta.
+
+    **NOTE: Requires a 'beta' parameter in a ParameterSet.**
+
+    ## Attributes
+
+    See attributes for [`IndividualPriorInitializerComponent`](IndividualPriorInitializerComponent.md).
+
+    ## Methods
+
+    See methods for [`IndividualPriorInitializerComponent`](IndividualPriorInitializerComponent.md).
+
+    {end_markdown BetaPrior}
+    """
     def __init__(self):
         super().__init__()
 
     def _extract_prior(self, solver):
         assert isinstance(solver, Solver)
-        pass
+
+        fe, re = unzip_x(
+            x=solver.x_opt,
+            num_groups=solver.model.data_inputs.group_sizes,
+            num_fe=solver.model.param_set.num_fe
+        )
+
+        beta_idx = solver.model.param_set.get_param_index('beta')
+
+        beta_fe_mean = fe[beta_idx]
+        beta_fe_std = np.std(re[:, beta_idx])
+
+        return [beta_fe_mean, beta_fe_std]
 
     def _update_parameter_set(self, parameter_set_prototype, solvers):
         param_set = parameter_set_prototype.clone()
@@ -73,16 +227,72 @@ class BetaPrior(JointPriorInitializerComponent):
 
 
 class PriorInitializer:
-    def __init__(self, prior_initializer_instances):
+    """
+    {begin_markdown PriorInitializer}
 
-        self.prior_initializer_instances = prior_initializer_instances
-        self.initializer_types = [c.initializer_type for c in self.prior_initializer_instances]
+    # `curvefit.initializer.initializer.PriorInitializer`
+    ## A prior initializer for a parameter set
+
+    For a given solver, model and parameter set there are a number of strategies to get
+    information to inform a prior for a later model fit. A `PriorInitializer` uses one or more
+    `PriorInitializerComponent`s to inform what priors should be for a new parameter set. Typically,
+    the data passed to `PriorInitializer` is only a subset of the data, for example a subset that
+    has a substantial number of data points that result in well-informed parameter estimates for all
+    parameters in a model. The updated parameter set that results from PriorInitializer.initialize()
+    has priors that are informed by whatever `PriorInitializerComponent`s were passed in.
+
+    These PriorInitializerComponents are **model-specification-specific**. You need to be aware of what
+    component you are passing in and that it matches your model_prototype. If it doesn't, an error will be thrown.
+    The requirements are listed in the description
+    sections of each [`PriorInitializerComponent`](PriorInitializerComponent.md).
+
+    ## Arguments
+
+    - `self.prior_initializer_components (List[PriorInitializerComponent])` a list of prior initializer
+        components (instantiated) to use in updating the parameter set
+
+    ## Attributes
+
+    - `self.component_types (List[str])`: list of the types of initializer components
+    - `self.joint_solver (curvefit.solvers.solver.Solver)`: a solver/model run on all of the data
+    - `self.individual_solvers (List[curvefit.solvers.solver.Solver]): a list of solver/models run on each
+        group in the data individually
+
+    ## Methods
+
+    ### `initialize`
+    For a given data, model prototype and solver prototype, run the prior initialization for all
+    prior initializer components and return an updated parameter set.
+
+    - `data (curvefit.core.data.Data)`: a Data object that represents all of the data that will be
+        used in the initialization (this will often be a subset of all available data)
+    - `model_prototype (curvefit.core.model.CoreModel)`: a model that will be used as the prototype
+        and cloned for the joint and individual fits
+    - `solver_prototype (curvefit.solvers.solver.Solver): a solver that will be used as the prototype
+        and cloned for the joint and individual fits
+
+    ## Usage
+
+    ```python
+    prior_initializer = PriorInitializer([LnAlphaBetaPrior(), BetaPrior()])
+    new_parameter_set = prior_initializer.initialize(
+        data=data, model_prototype=model_prototype,
+        solver_prototype=solver_prototype, parameter_set_prototype
+    )
+    ```
+
+    {end_markdown PriorInitializer}
+    """
+    def __init__(self, prior_initializer_components):
+
+        self.prior_initializer_components = prior_initializer_components
+        self.component_types = [c.component_type for c in self.prior_initializer_components]
 
         self.joint_solver = None
         self.individual_solvers = None
 
     @staticmethod
-    def run_joint(data, model_prototype, solver_prototype):
+    def _run_joint(data, model_prototype, solver_prototype):
         model = model_prototype.clone()
         solver = solver_prototype.clone()
 
@@ -91,8 +301,8 @@ class PriorInitializer:
         return solver
 
     @staticmethod
-    def run_individual(data, model_prototype, solver_prototype):
-        solvers = {}
+    def _run_individual(data, model_prototype, solver_prototype):
+        solvers = list()
 
         for group in data.groups:
             model = model_prototype.clone()
@@ -103,34 +313,34 @@ class PriorInitializer:
             solver.set_model_instance(model)
             solver.fit(data=group_data)
 
-            solvers[group] = solver
+            solvers.append(solver)
 
         return solvers
 
-    def initialize(self, data, model_prototype, solver_prototype, parameter_set_prototype):
+    def initialize(self, data, model_prototype, solver_prototype):
 
-        if 'individual' in self.initializer_types:
-            self.individual_solvers = self.run_individual(
+        if 'individual' in self.component_types:
+            self.individual_solvers = self._run_individual(
                 data, model_prototype=model_prototype,
                 solver_prototype=solver_prototype
             )
-        if 'joint' in self.initializer_types:
-            self.joint_solver = self.run_joint(
+        if 'joint' in self.component_types:
+            self.joint_solver = self._run_joint(
                 data, model_prototype=model_prototype,
                 solver_prototype=solver_prototype
             )
 
-        param_set = parameter_set_prototype.clone()
+        param_set = model_prototype.param_set.clone()
 
-        for initializer in self.prior_initializer_instances:
-            if initializer.initializer_type == 'joint':
-                param_set = initializer._update_parameter_set(
-                    solvers=self.joint_solver,
+        for component in self.prior_initializer_components:
+            if component.component_type == 'joint':
+                param_set = component._update_parameter_set(
+                    solver=self.joint_solver,
                     parameter_set_prototype=param_set
                 )
-            elif initializer.initializer_type == 'individual':
-                param_set = initializer._update_parameter_set(
-                    solvers=self.individual_solvers,
+            elif component.component_type == 'individual':
+                param_set = component._update_parameter_set(
+                    solver=self.individual_solvers,
                     parameter_set_prototype=param_set
                 )
 

--- a/src/curvefit/models/core_model.py
+++ b/src/curvefit/models/core_model.py
@@ -146,14 +146,17 @@ class CoreModel(Prototype):
 
         return grad
 
-    def predict(self, x, t, predict_fun=None):
-        params = effects2params(
+    def get_params(self, x):
+        return effects2params(
             x,
             self.data_inputs.group_sizes,
             self.data_inputs.covariates_matrices,
             self.param_set.link_fun,
             self.data_inputs.var_link_fun,
         )
+
+    def predict(self, x, t, predict_fun=None):
+        params = self.get_params(x=x)
         if predict_fun is None:
             predict_fun = self.curve_fun 
         

--- a/src/curvefit/models/core_model.py
+++ b/src/curvefit/models/core_model.py
@@ -14,7 +14,7 @@ class DataInputs:
     """
     {begin_markdown DataInputs}
 
-    {spell_markdown ndarray gprior param}
+    {spell_markdown ndarray gprior param init}
 
     # `curvefit.core.core_model.DataInputs`
     ## Provides the required data inputs for a `curvefit.core.core_model.Model`

--- a/src/curvefit/models/core_model.py
+++ b/src/curvefit/models/core_model.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import List, Callable, Tuple
 import numpy as np
 
+from curvefit.core.prototype import Prototype
 from curvefit.core.objective_fun import objective_fun
 from curvefit.core.effects2params import effects2params
 
@@ -68,7 +69,7 @@ class DataNotFoundError(Exception):
     pass
 
 
-class CoreModel:
+class CoreModel(Prototype):
     """
     {begin_markdown Model}
 
@@ -135,7 +136,7 @@ class CoreModel:
         if self.data_inputs is None:
             self.data_inputs = convert_inputs(self.param_set, data)
         finfo = np.finfo(float)
-        step  = finfo.tiny / finfo.eps
+        step = finfo.tiny / finfo.eps
         x_c = x + 0j
         grad = np.zeros(x.size)
         for i in range(x.size):

--- a/src/curvefit/solvers/solvers.py
+++ b/src/curvefit/solvers/solvers.py
@@ -1,16 +1,17 @@
 import numpy as np
+from copy import deepcopy
 import scipy.optimize as sciopt
 
-from curvefit.core.effects2params import effects2params
 
 class ModelNotDefinedError(Exception):
     pass
+
 
 class SolverNotDefinedError(Exception):
     pass
 
 
-class Base:
+class Solver:
 
     def __init__(self, model_instance=None):
         self.model = model_instance
@@ -32,8 +33,11 @@ class Base:
     def fit(self, data, x_init=None, options=None):
         raise NotImplementedError()
 
+    def clone(self):
+        return deepcopy(self)
 
-class ScipyOpt(Base):
+
+class ScipyOpt(Solver):
 
     def fit(self, data, x_init=None, options=None):
         if x_init is None:
@@ -51,7 +55,7 @@ class ScipyOpt(Base):
         self.fun_val_opt = result.fun
 
 
-class Composite(Base):
+class CompositeSolver(Solver):
 
     def __init__(self):
         super().__init__(model_instance=None)
@@ -79,7 +83,7 @@ class Composite(Base):
             raise SolverNotDefinedError()
 
 
-class MultipleInitializations(Composite):
+class MultipleInitializations(CompositeSolver):
 
     def __init__(self, num_init, sample_fun):
         super().__init__()
@@ -97,6 +101,6 @@ class MultipleInitializations(Composite):
                 self.solver.fit(data, xs_init[i], options=options)
                 fun_vals.append(self.solver.fun_val_opt)
                 xs_opt.append(self.solver.x_opt)
-            
+
             self.x_opt = xs_opt[np.argmin(fun_vals)]
             self.fun_val_opt = np.min(fun_vals)

--- a/tests/models/test_core_model.py
+++ b/tests/models/test_core_model.py
@@ -13,6 +13,7 @@ n_B = 6
 n_C = 7
 n_total = n_A + n_B + n_C
 
+
 @pytest.fixture
 def data():
     df = pd.DataFrame({

--- a/tests/models/test_core_model.py
+++ b/tests/models/test_core_model.py
@@ -31,12 +31,12 @@ def data():
 
 @pytest.fixture
 def param_set():
-    variable1 = Variable('intercept', lambda x:x, 0.0, 0.3, re_bounds=[0.0, 1.0])
-    variable2 = Variable('intercept', lambda x:x, 0.1, 0.4, re_bounds=[0.0, 2.0])
-    variable3 = Variable('intercept', lambda x:x, 0.2, 0.5, re_bounds=[0.0, 3.0])
+    variable1 = Variable('intercept', lambda x: x, 0.0, 0.3, re_bounds=[0.0, 1.0])
+    variable2 = Variable('intercept', lambda x: x, 0.1, 0.4, re_bounds=[0.0, 2.0])
+    variable3 = Variable('intercept', lambda x: x, 0.2, 0.5, re_bounds=[0.0, 3.0])
     parameter1 = Parameter('p1', np.exp, [variable1])
     parameter2 = Parameter('p2', np.exp, [variable2])
-    parameter3 = Parameter('p2', np.exp, [variable3] * 2)
+    parameter3 = Parameter('p3', np.exp, [variable3] * 2)
     parameter_set = ParameterSet([parameter1, parameter2, parameter3])
     assert parameter_set.num_fe == 4
     return parameter_set

--- a/tests/solvers/test_solvers.py
+++ b/tests/solvers/test_solvers.py
@@ -4,6 +4,7 @@ from scipy.optimize import rosen, rosen_der
 
 from curvefit.solvers.solvers import ScipyOpt, MultipleInitializations
 
+
 class Rosenbrock:
 
     def __init__(self, n_dim=2):
@@ -11,15 +12,19 @@ class Rosenbrock:
         self.bounds = np.array([[-2.0, 2.0]] * n_dim)
         self.x_init = np.array([-1.0] * n_dim)
 
-    def objective(self, x, data):
+    @staticmethod
+    def objective(x, data):
         return rosen(x)
 
-    def gradient(self, x, data):
+    @staticmethod
+    def gradient(x, data):
         return rosen_der(x)
+
 
 @pytest.fixture(scope='module')
 def rb():
     return Rosenbrock()
+
 
 class TestBaseSolvers:
 


### PR DESCRIPTION
**MAIN**:
- Added `PriorInitializer` class that initializes `Parameter` or `ParameterFunction` priors (uses `PriorInitializerComponent`)
- Updated `Parameter` so that it takes a new class `ParameterFunction` rather than a tuple (added so that we can index names of parameter functions for the `PriorInitializer`)
- Added some helper functions to `Parameter` to index by names
- Added a `Prototype` class (naming from Design Patterns :)) so that certain classes can be "cloned" during the prior initialization or during predictive validity
- Documented `PriorInitializer` and all of its components
- Updated tests for `ParameterSet` to work with `ParameterFunction`

**Additional**:
- Updated documentation and formatting to `effects2params`
- Added a `get_params` method that uses `effects2params` in the `CoreModel` class for convenience

**Quick fixes**:
- Passing in `col_obs_se` to the `DataSpecs` class
- Updated naming for `CompositeSolver` so that it's not "composite" (since we might have other composites floating around that are not solvers later on)
- Quick testing changes for formatting and small bugs