### PR TITLE
Fix example/random_effects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests:
 examples:
 	python example/get_started.py
 	python example/covariate.py
-	# python example/random_effects.py
+	python example/random_effects.py
 	python example/sizes_to_indices.py
 	python example/param_time_fun.py
 	python example/unzip_x.py

--- a/bin/extract_md.py
+++ b/bin/extract_md.py
@@ -12,6 +12,7 @@ file_list = [
     'example/effects2params.py',
     'example/objective_fun.py',
     'example/prior_initializer.py',
+    'example/random_effects.py',
 
     'bin/extract_md.py',
     'bin/get_cppad_py.py',
@@ -37,7 +38,7 @@ file_list = [
     'src/curvefit/uncertainty/residuals.py',
     'src/curvefit/uncertainty/predictive_validity.py',
     'src/curvefit/uncertainty/draws.py',
-  
+
     'src/curvefit/initializer/initializer.py',
     'src/curvefit/initializer/initializer_component.py',
 ]

--- a/example/objective_fun.py
+++ b/example/objective_fun.py
@@ -43,16 +43,16 @@ def gaussian_loss(x):
 # set parameters for the objective function
 num_fe = num_param
 num_re = num_group * num_fe
-fe = numpy.array(range(num_fe), dtype=float) / num_fe
-re = numpy.array(range(num_re), dtype=float) / num_re
+fe     = numpy.array(range(num_fe), dtype=float) / num_fe
+re     = numpy.array(range(num_re), dtype=float) / num_re
 group_sizes = (numpy.arange(num_group) + 1) * 2
 
 # observations
-x = numpy.concatenate((fe, re))
+x       = numpy.concatenate((fe, re))
 num_obs = sum(group_sizes)
-t = numpy.arange(num_obs, dtype=float)
-obs = numpy.arange(num_obs, dtype=float) / num_obs
-obs_se = (obs + 1.0) / 10.0
+t       = numpy.arange(num_obs, dtype=float)
+obs     = numpy.arange(num_obs, dtype=float) / num_obs
+obs_se  = (obs + 1.0) / 10.0
 
 # covariates
 covs = list()
@@ -87,6 +87,7 @@ re_gprior[:, :, 1] = (1.0 + re_gprior[:, :, 0] / 3.0)
 param_gprior_std = (1.0 + param_gprior_mean / 2.0)
 param_gprior_fun = identity_fun
 param_gprior = [param_gprior_fun, param_gprior_mean, param_gprior_std]
+re_zero_sum_std = numpy.array( num_fe * [numpy.inf] )
 # -----------------------------------------------------------------------
 # call to objective_fun
 obj_val = objective_fun(
@@ -102,7 +103,8 @@ obj_val = objective_fun(
     var_link_fun,
     fe_gprior,
     re_gprior,
-    param_gprior
+    param_gprior,
+    re_zero_sum_std,
 )
 # -----------------------------------------------------------------------
 # check objective_fun return value

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ nav:
   - User Examples:
     - get_started_xam: 'extract_md/get_started_xam.md'
     - covariate_xam: 'extract_md/covariate_xam.md'
-    # - random_effect_xam: 'extract_md/random_effect_xam.md'
+    - random_effect_xam: 'extract_md/random_effect_xam.md'
     - param_time_fun_xam: 'extract_md/param_time_fun_xam.md'
     - prior_initializer_xam: 'extract_md/prior_initializer_xam.md'
   - Developer Doc:

--- a/src/curvefit/core/parameter.py
+++ b/src/curvefit/core/parameter.py
@@ -33,6 +33,8 @@ class Variable:
     - `var_link_fun (Callable)`: link function for the variable
     - `fe_init (float)`: initial value to be used in the optimization for the fixed effect
     - `re_init (float)`: initial value to be used in the optimization for the random effect
+    - `re_zero_sum_std (float)`: standard deviation of the zero sum prior
+        for he random effects corresponding to this variable.
     - `fe_gprior (optional, List[float])`: list of Gaussian priors
         the fixed effect where the first element is the prior
         mean and the second element is the prior standard deviation
@@ -61,6 +63,7 @@ class Variable:
     var_link_fun: Callable
     fe_init: float
     re_init: float
+    re_zero_sum_std: float = field(default=np.inf)
     fe_gprior: List[float] = field(default_factory=lambda: [0.0, np.inf])
     re_gprior: List[float] = field(default_factory=lambda: [0.0, np.inf])
     fe_bounds: List[float] = field(default_factory=lambda: [-np.inf, np.inf])
@@ -130,6 +133,7 @@ class Parameter:
     var_link_fun: List[Callable] = field(init=False)
     fe_init: List[float] = field(init=False)
     re_init: List[float] = field(init=False)
+    re_zero_sum_std: List[float] = field(init=False)
     fe_gprior: List[List[float]] = field(init=False)
     re_gprior: List[List[float]] = field(init=False)
     fe_bounds: List[List[float]] = field(init=False)
@@ -234,6 +238,7 @@ class ParameterSet(Prototype):
     var_link_fun: List[List[Callable]] = field(init=False)
     fe_init: List[List[float]] = field(init=False)
     re_init: List[List[float]] = field(init=False)
+    re_zero_sum_std: List[List[float]] = field(init=False)
     fe_gprior: List[List[List[float]]] = field(init=False)
     re_gprior: List[List[List[float]]] = field(init=False)
     fe_bounds: List[List[List[float]]] = field(init=False)

--- a/src/curvefit/models/base.py
+++ b/src/curvefit/models/base.py
@@ -47,6 +47,10 @@ class DataInputs:
         first element is a composite function of all of the parameter functional priors;
         second element is another tuple and the first element is a
         list of means, the second element is a list of standard deviations
+    - `re_zero_sum_std: (np.ndarray)`: is a vector with length equal to the
+        number of fixed effects. It j-th component is the standard deviation
+        of the zero sum of the random effects corresponding to the j-th
+        fixed effect.
 
     {end_markdown DataInputs}
     """
@@ -64,6 +68,7 @@ class DataInputs:
     fe_gprior: np.ndarray = None
     re_gprior: np.ndarray = None
     param_gprior_info: Tuple[Callable, Tuple[List[float], List[float]]] = None
+    re_zero_sum_std: np.ndarray = None
 
 
 class Model(Prototype):
@@ -134,6 +139,3 @@ class Model(Prototype):
             x_c[i] -= step*1j
 
         return grad
-
-
-

--- a/src/curvefit/models/core_model.py
+++ b/src/curvefit/models/core_model.py
@@ -91,6 +91,7 @@ class CoreModel(Model):
             fe_gprior=self.data_inputs.fe_gprior,
             re_gprior=self.data_inputs.re_gprior,
             param_gprior=self.data_inputs.param_gprior_info,
+            re_zero_sum_std=self.data_inputs.re_zero_sum_std
         )
 
     def get_params(self, x, expand=False):
@@ -107,7 +108,7 @@ class CoreModel(Model):
         params = self.get_params(x=x)
         if predict_fun is None:
             predict_fun = self.curve_fun
-        
+
         if not is_multi_groups:
             return predict_fun(t, params[:, 0])
         else:
@@ -190,6 +191,8 @@ class CoreModel(Model):
         else:
             param_gprior_info = None
 
+        re_zero_sum_std = np.array(reduce(iconcat, self.param_set.re_zero_sum_std, []))
+
         self.data_inputs = DataInputs(
             t=t,
             obs=obs,
@@ -204,4 +207,5 @@ class CoreModel(Model):
             fe_gprior=fe_gprior,
             re_gprior=re_gprior,
             param_gprior_info=param_gprior_info,
+            re_zero_sum_std=re_zero_sum_std
         )

--- a/src/curvefit/solvers/solvers.py
+++ b/src/curvefit/solvers/solvers.py
@@ -68,6 +68,7 @@ class Solver(Prototype):
 
     def __init__(self, model_instance=None):
         self.model = model_instance
+        self.success = None
         self.x_opt = None
         self.fun_val_opt = None
         self.options = None
@@ -87,7 +88,7 @@ class Solver(Prototype):
 
     def set_options(self, options: dict):
         self.options = options
-    
+
     def get_fit_status(self):
         return self.status
 
@@ -125,6 +126,7 @@ class ScipyOpt(Solver):
             options=options if options is not None else self.options,
         )
 
+        self.success = result.success
         self.x_opt = result.x
         self.fun_val_opt = result.fun
         self.status = result.message
@@ -250,9 +252,9 @@ class GaussianMixturesIntegration(CompositeSolver):
         self.gm_model = gm_model
 
     def fit(self, data, x_init=None, options=None):
-        if self.assert_solver_defined() is True:         
+        if self.assert_solver_defined() is True:
             self.solver.fit(data, x_init, options)
-            model = self.get_model_instance()  
+            model = self.get_model_instance()
             self.input_curve_fun = model.curve_fun
             params = effects2params(
                 self.solver.x_opt,
@@ -265,8 +267,8 @@ class GaussianMixturesIntegration(CompositeSolver):
             self.gm_model.set_params(params[:, 0])
             gm_solver = ScipyOpt(self.gm_model)
             data_inputs_gm = DataInputs(
-                t=model.data_inputs.t, 
-                obs=model.data_inputs.obs, 
+                t=model.data_inputs.t,
+                obs=model.data_inputs.obs,
                 obs_se=model.data_inputs.obs_se,
             )
             obs_gau_pdf = data_translator(data_inputs_gm.obs, model.curve_fun, gaussian_pdf)


### PR DESCRIPTION
I had to add a new feature to the core model called re_sum_zero_std.
This is a standard deviation for the prior that the sum of the random effects for each fixed effect is zero. If you do not specify this option for a variable, infinity is used for the standard deviation. This makes the code backward compatible.

You will also note, if you inspect the example, that i had to change the link function for the alpha variable from exp to log (otherwise the scaling is very poor and the optimizer cannot make progress).